### PR TITLE
Unique base records

### DIFF
--- a/lib/sql_dust/utils/compose_utils.ex
+++ b/lib/sql_dust/utils/compose_utils.ex
@@ -32,6 +32,11 @@ defmodule SqlDust.ComposeUtils do
       def offset(arg)                  do offset(options, arg) end
       def offset(options, arg)         do put(options, :offset, arg) end
 
+      def unique                       do unique(true) end
+      def unique(%{} = options)        do unique(options, true) end
+      def unique(bool)                 do unique(options, bool) end
+      def unique(options, bool)        do put(options, :unique, bool) end
+
       def variables(map)               do variables(options, map) end
       def variables(options, map)      do merge(options, :variables, map) end
 
@@ -60,7 +65,7 @@ defmodule SqlDust.ComposeUtils do
 
         from = options.from
         schema = options.schema
-        options = Map.take(options, [:select, :join_on, :where, :group_by, :order_by, :limit, :offset, :variables, :adapter])
+        options = Map.take(options, [:select, :join_on, :where, :group_by, :order_by, :limit, :offset, :unique, :variables, :adapter])
                   |> Enum.reduce(%{from: options.from}, fn({key, value}, map) ->
                     if is_nil(value) do
                       map

--- a/test/sql_dust/query_test.exs
+++ b/test/sql_dust/query_test.exs
@@ -287,6 +287,43 @@ defmodule SqlDust.QueryTest do
     }
   end
 
+  test "unique returns SqlDust containing :unique option (at default true)" do
+    query_dust = unique
+
+    assert query_dust == %SqlDust{
+      unique: true
+    }
+  end
+
+  test "unique returns SqlDust containing :unique option" do
+    query_dust = unique(false)
+
+    assert query_dust == %SqlDust{
+      unique: false
+    }
+  end
+
+  test "unique sets :unique option of passed SqlDust" do
+    query_dust = select("id")
+      |> unique(true)
+
+    assert query_dust == %SqlDust{
+      select: ["id"],
+      unique: true
+    }
+  end
+
+  test "unique overwrites :unique option within passed SqlDust" do
+    query_dust = select("id")
+      |> unique(true)
+      |> unique(false)
+
+    assert query_dust == %SqlDust{
+      select: ["id"],
+      unique: false
+    }
+  end
+
   test "schema returns SqlDust containing :schema option" do
     query_dust = schema(%{
       "users": %{
@@ -368,6 +405,7 @@ defmodule SqlDust.QueryTest do
           companies: %{"address": %{cardinality: :has_one}}
         }
       )
+      |> unique
       |> to_sql
 
     assert sql == {"""
@@ -380,6 +418,7 @@ defmodule SqlDust.QueryTest do
       LEFT JOIN `companies` `company` ON `company`.`id` = `u`.`company_id`
       LEFT JOIN `addresses` `company.address` ON `company.address`.`company_id` = `company`.`id` AND `company.address`.`is_current` = ?
       WHERE (`u`.`id` > ?) AND (`company`.`name` LIKE ?)
+      GROUP BY `u`.`id`
       ORDER BY `u`.`name`, `company`.`name`
       LIMIT ?
       """,


### PR DESCRIPTION
With this feature, you can instruct SqlDust to ensure always getting unique base records. Despite of joining with collection associations, by adding `group_by: "id"` when necessary.