### PR TITLE
Ignore empty WHERE statements.

### DIFF
--- a/lib/sql_dust.ex
+++ b/lib/sql_dust.ex
@@ -107,10 +107,7 @@ defmodule SqlDust do
 
     options = parse_conditions(where, options, :where)
     options = parse_conditions(having, options, :having)
-
-    if length(where) == 0 do
-      options = Map.delete(options, :where)
-    end
+    options = if length(where) == 0, do: Map.delete(options, :where), else: options
 
     options
   end

--- a/lib/sql_dust.ex
+++ b/lib/sql_dust.ex
@@ -87,6 +87,7 @@ defmodule SqlDust do
     options
   end
 
+  defp derive_where(%{where: [""]} = options), do: options |> Map.put(:where, [])
   defp derive_where(options) do
     if where = MapUtils.get(options, :where) do
       where = where |> wrap_conditions

--- a/lib/sql_dust.ex
+++ b/lib/sql_dust.ex
@@ -117,7 +117,7 @@ defmodule SqlDust do
     |> Enum.filter(fn(condition) ->
       case condition do
         condition when is_binary(condition) ->
-          condition |> String.trim() |> String.length > 0
+          condition |> String.strip() |> String.length > 0
         [""|_tail] -> false
         _ -> true
       end

--- a/test/sql_dust_test.exs
+++ b/test/sql_dust_test.exs
@@ -985,4 +985,12 @@ defmodule SqlDustTest do
       FROM `people` `u`
       """, []}
   end
+
+  test "ignore WHERE with empty statement" do
+    assert SqlDust.from("users", %{where: [""]}) == {"""
+      SELECT `u`.*
+      FROM `users` `u`
+      """, []
+    }
+  end
 end

--- a/test/sql_dust_test.exs
+++ b/test/sql_dust_test.exs
@@ -996,7 +996,7 @@ defmodule SqlDustTest do
     assert SqlDust.from("users", %{where: ["", "id = 1", "    "]}) == {"""
       SELECT `u`.*
       FROM `users` `u`
-      WHERE `u`.`name` = 1
+      WHERE (`u`.`id` = 1)
       """, []
     }
   end

--- a/test/sql_dust_test.exs
+++ b/test/sql_dust_test.exs
@@ -992,5 +992,12 @@ defmodule SqlDustTest do
       FROM `users` `u`
       """, []
     }
+
+    assert SqlDust.from("users", %{where: ["", "id = 1", "    "]}) == {"""
+      SELECT `u`.*
+      FROM `users` `u`
+      WHERE `u`.`name` = 1
+      """, []
+    }
   end
 end


### PR DESCRIPTION
Passing the option %{where: [""]} now results in 
bad sql syntax `WHERE ()`.
If a where statement is empty, we can just ignore 
it.