### PR TITLE
Features/dust paths

### DIFF
--- a/lib/sql_dust/utils/path_utils.ex
+++ b/lib/sql_dust/utils/path_utils.ex
@@ -4,10 +4,10 @@ defmodule SqlDust.PathUtils do
 
   def prepend_path_aliases([], options), do: {[], options}
   def prepend_path_aliases([sql_line | sql_lines], options) do
-    {prepedend_sql_line, prepended_options} = prepend_path_aliases(sql_line, options)
-    {prepedend_sql_lines, acc_prepended_options} = prepend_path_aliases(sql_lines, prepended_options)
+    {prepended_sql_line, prepended_options} = prepend_path_aliases(sql_line, options)
+    {prepended_sql_lines, acc_prepended_options} = prepend_path_aliases(sql_lines, prepended_options)
 
-    {[prepedend_sql_line | prepedend_sql_lines], acc_prepended_options}
+    {[prepended_sql_line | prepended_sql_lines], acc_prepended_options}
   end
   def prepend_path_aliases(sql, options) when sql == "*", do: {sql, options}
   def prepend_path_aliases(sql, options) when is_binary(sql) do

--- a/lib/sql_dust/utils/path_utils.ex
+++ b/lib/sql_dust/utils/path_utils.ex
@@ -87,7 +87,7 @@ defmodule SqlDust.PathUtils do
 
   def scan_excluded(sql) do
     excluded = []
-      |> Enum.concat(scan_quoted(sql))
+      |> Enum.concat(scan_strings(sql))
       |> Enum.concat(scan_variables(sql))
       |> Enum.concat(scan_functions(sql))
       |> Enum.concat(aliases = (sql |> scan_aliases() |> List.flatten |> Enum.uniq))

--- a/lib/sql_dust/utils/scan_utils.ex
+++ b/lib/sql_dust/utils/scan_utils.ex
@@ -13,10 +13,13 @@ defmodule SqlDust.ScanUtils do
   def split_arguments(sql) do
     excluded = scan_strings(sql)
 
-    {sql, excluded} = numerize_patterns(sql, excluded)
+    {sql, excluded} =
+      sql
+      |> numerize_patterns(excluded)
       |> numerize_parenthesized(excluded)
 
-    {list, _} = sql
+    {list, _} =
+      sql
       |> String.split(~r/\s*,\s*/)
       |> Enum.reduce({[], excluded}, fn(sql, {list, excluded}) ->
         sql = interpolate_parenthesized(sql, excluded)
@@ -80,7 +83,7 @@ defmodule SqlDust.ScanUtils do
   end
 
   def scan_reserved_words(sql) do
-    Regex.scan(~r/\b(distinct|and|or|is|like|rlike|regexp|in|between|not|null|sounds|soundex|asc|desc|true|false)\b/i, sql)
+    Regex.scan(~r/\b(distinct|key|and|or|is|like|rlike|regexp|in|between|not|null|sounds|soundex|asc|desc|true|false)\b/i, sql)
   end
 
   def numerize_patterns(sql, patterns) do

--- a/lib/sql_dust/utils/scan_utils.ex
+++ b/lib/sql_dust/utils/scan_utils.ex
@@ -11,7 +11,7 @@ defmodule SqlDust.ScanUtils do
   end
 
   def split_arguments(sql) do
-    excluded = scan_quoted(sql)
+    excluded = scan_strings(sql)
 
     {sql, excluded} = numerize_patterns(sql, excluded)
       |> numerize_parenthesized(excluded)
@@ -50,11 +50,11 @@ defmodule SqlDust.ScanUtils do
     end
   end
 
-  def scan_quoted(sql) do
+  def scan_strings(sql) do
     Regex.scan(~r/(["'])(?:(?=(\\?))\2.)*?\1/, sql)
       |> Enum.reduce([], fn
-        ([""|_], quoted) -> quoted
-        ([match|_], quoted) -> [match | quoted]
+        ([""|_], strings) -> strings
+        ([match|_], strings) -> [match | strings]
       end)
       |> Enum.reverse()
   end
@@ -120,7 +120,7 @@ defmodule SqlDust.ScanUtils do
   end
 
   def interpolate_variables(sql, variables, initial_variables) do
-    excluded = scan_quoted(sql)
+    excluded = scan_strings(sql)
     sql = numerize_patterns(sql, excluded)
 
 

--- a/lib/sql_dust/utils/scan_utils.ex
+++ b/lib/sql_dust/utils/scan_utils.ex
@@ -75,6 +75,10 @@ defmodule SqlDust.ScanUtils do
     Regex.scan(~r/ AS .+$/i, sql)
   end
 
+  def scan_dust_paths(sql) do
+    Regex.scan(~r/\[[a-z0-9_\.]+\]/i, sql)
+  end
+
   def scan_reserved_words(sql) do
     Regex.scan(~r/\b(distinct|and|or|is|like|rlike|regexp|in|between|not|null|sounds|soundex|asc|desc|true|false)\b/i, sql)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule SqlDust.Mixfile do
 
   def project do
     [app: :sql_dust,
-     version: "0.3.10",
+     version: "0.4.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/sql_dust/query_test.exs
+++ b/test/sql_dust/query_test.exs
@@ -418,9 +418,6 @@ defmodule SqlDust.QueryTest do
   end
 
   test "escapes fields with same name as function" do
-    # Data.sqlify: not-querified: '%SqlDust{adapter: nil, from: "Todo", group_by: nil, join_on: nil, limit: 60, offset: nil, order_by: ["id ASC"], schema: %{Role: %{:table_name => "roles", "users" => %{association_foreign_key: "user_id", association_primary_key : "id", bridge_table: "roles_users", cardinality: :has_and_belongs_to_many, foreign_key: "role_id", primary_key: "id", resource: "User"}}, Todo: %{table_name: "todos"}, User: %{:table_name => "users", "locale" => %{cardinality: :belongs_to, foreign_key: " locale_id", table_name: "user_locale_list"}, "roles" => %{association_foreign_key: "role_id", association_primary_key: "id", bridge_table: "roles_users", cardinality: :has_and_belongs_to_many, foreign_key: "user_id", primary_key: "id", resource: "Role"}}} , select: ["content AS content", "pdf_report AS pdf_report.pdf_report", "pdf_report_source AS pdf_report.pdf_report_source", "title AS title", "regexp AS regexp", "id"], unique: true, variables: %{scope: "NULL", scope_value: "NULL"}, where: nil}'
-
-
     {sql, _} = select("[regexp] as regexp")
                |> select("[id]")
                |> select("[key.in.value]")


### PR DESCRIPTION
SqlDust supports path-notation

When fields are passed to SqlDust with brackets, then they will be seen
as part of a path. This means that these fields will not be scanned as
reserved keyword, or as a number.
These fields will be prepended with a table-alias. and will result in
JOINS when necessary.

Example:
SELECT [key], [regexp] as regexp FROM users
