### PR TITLE
SQLDust will prepend column-names within the MySql unquoted range

### DIFF
--- a/lib/sql_dust/utils/path_utils.ex
+++ b/lib/sql_dust/utils/path_utils.ex
@@ -107,7 +107,7 @@ defmodule SqlDust.PathUtils do
   end
 
   defp scan_and_prepend_path_aliases(sql, options) do
-    ~r/(?:\.\*|\w+[a-zA-Z]+\w*(?:\.(?:\*|\w{2,}))*)/
+    ~r/(?:\.\*|\w*[a-zA-Z_\$]\w*(?:\.(?:\*|\w{2,}))*)/
     |> Regex.split(sql, [include_captures: true])
     |> analyze_aliases([], options, false)
   end

--- a/test/sql_dust_test.exs
+++ b/test/sql_dust_test.exs
@@ -45,6 +45,34 @@ defmodule SqlDustTest do
       """, []}
   end
 
+  test "selecting weirdly named columns of the base resource (passing a list)" do
+    options = %{
+      select: ["id", "first_name", "last_name", "m2"]
+    }
+
+    assert SqlDust.from("users", options) == {
+      "SELECT\n  `u`.`id`,\n  `u`.`first_name`,\n  `u`.`last_name`,\n  `u`.`m2`\nFROM `users` `u`\n",
+      []}
+  end
+
+  test "selecting weirdly named columns of the base resource (passing a map)" do
+    options = %{
+      select: ["id", "name", "m2"],
+      where: [
+        ["name LIKE ? OR name LIKE ?", "%Paul%", "%Engel%"]
+      ]
+    }
+
+    assert SqlDust.from("users", options) == {
+      """
+      SELECT `u`.`id`, `u`.`name`, `u`.`m2`
+      FROM `users` `u`
+      WHERE (`u`.`name` LIKE ? OR `u`.`name` LIKE ?)
+      """,
+      ["%Paul%", "%Engel%"]
+    }
+  end
+
   test "interpolating variables" do
     options = %{
       select: ["id", "CONCAT(name, <<postfix>>)"],


### PR DESCRIPTION
A column-name ending with a number would fail to be prepended with the
table-alias.
With this change the allowed range for unquoted column-names is
supported. This range is: a-z, A-Z, 0-9, _, $